### PR TITLE
Make sheet-eval include the bottom right corner (br) of a cell-range

### DIFF
--- a/grid/grid-test.rkt
+++ b/grid/grid-test.rkt
@@ -29,10 +29,10 @@
                       3
                       ,(cell-app '+
                                  (list (cell-range (cell-ref 0 -2 #f #t)
-                                                   (cell-ref 1 3 #f #f))
+                                                   (cell-ref 0 2 #f #f))
                                        (cell-value-return -5)))
                       ,(cell-range (cell-ref 0 0 #f #f)
-                                   (cell-ref 1 2 #f #f)))))))
+                                   (cell-ref 0 1 #f #f)))))))
              
              (check-equal?
               (sheet-eval example-sheet)
@@ -43,7 +43,7 @@
                    `((1 2 3 empty 4
                         ,(cell-app '+
                                    (list (cell-range (cell-ref 0 0 #f #f)
-                                                     (cell-ref 1 5 #f #f)))))))))
+                                                     (cell-ref 0 4 #f #f)))))))))
              (check-equal?
               (sheet-eval example-sheet)
               (mutable-array #[#[1.0 2.0 3.0 'empty 4.0 10.0]])))
@@ -62,7 +62,7 @@
                                '+
                                (list (cell-range
                                       (cell-ref 0 0 #f #f)
-                                      (cell-ref 1 5 #f #f)))))))))))
+                                      (cell-ref 0 4 #f #f)))))))))))
              (check-=
               (array-ref (sheet-eval example-sheet) #(0 5))
               3.0

--- a/grid/sheet.rkt
+++ b/grid/sheet.rkt
@@ -136,13 +136,15 @@ An abstract representation of spreadsheets
                [col (+ (cell-ref-col r) (vector-ref v 0))]
                [row (+ (cell-ref-row r) (vector-ref v 1))]))
 
-;; take two vectors comprising a range (top left and bottom right),
-;; and return the size of the range (as a vector).  The origin is used
-;; to resolve relative references.
+;; take two vectors comprising a range (top left and bottom right,
+;; both included in the range), and return the size of the range (as a
+;; vector).  The origin is used to resolve relative references.
 ;;
 ;; cell-ref? cell-ref? vector? -> vector?
 (define (cell-range-extent tl br origin)
-  (vector-map - (cell-ref->vector br origin) (cell-ref->vector tl origin)))
+  ;; range is inclusive of tl and br, hence the '#(-1 -1) adjustment
+  (vector-map - (cell-ref->vector br origin) (cell-ref->vector tl origin)
+              #(-1 -1)))
 
 
 ;;; Indexing


### PR DESCRIPTION
E.g. following this commit, the range referring to the single cell #(0 0) is
  (cell-range (cell-ref 0 0 #f #f) (cell-ref 0 0 #f #f))
instead of
  (cell-range (cell-ref 0 0 #f #f) (cell-ref 1 1 #f #f)).