### PR TITLE
Tidying up sheet and grid

### DIFF
--- a/grid/grid.rkt
+++ b/grid/grid.rkt
@@ -1,48 +1,44 @@
 #lang racket/base
 
 #|
-A little language for creating sheets
+A little language for creating sheets. (Uses functions, not syntax.)
+
+Syntax:
+
+  (sheet #:name "mysheet"
+    (row 10 20 (cell))  ;; the last entry is a blank cell
+    (row (cell 40) (cell 50 "a-cell") (cell `(+ 1 ,(ref "a-cell")))))
 
 TODO
- - Import sheet with a prefix to solve all the annoying name clashes
  - All references are converted to relative cell references and names are removed
  - Names aren't very consistent. We're using "id" in the context of a reference to mean a reference
    that should be turned into an A1-style reference, rather than a named reference. 
  - How to name: constructors? converters? parsers? 
- - The interplay between <x-spec>, (x ...) and so on is unclear. I suppose some documentation might
-   help here.
   - Doesn't cope with rows of unequal length
 
-<sheet-spec> ::=
-  (sheet <row-spec> ... #:name string?)
-
-<row-spec> ::=
-   (row <cell-spec> ...)  
-
-<cell-spec> ::=
-  atomic-value?
-| (cell <expression> [#:name name])
-| (blank)
-
-<expression> ::=
-    atomic-value?
-  | (ref string?) 
-  | (list symbol? <expression> ...)
 |#
 
 (require
  racket/contract
  math/array
  (only-in racket/list check-duplicates)
- (rename-in "sheet.rkt"
-            [sheet sheet-type] ; because we're exporting functions `sheet` and `cell`
-            [cell cell-type]))
+ (prefix-in s: "sheet.rkt"))
 
-(provide sheet
-         row
-         cell
-         ref
-         blank)
+(provide
+ (contract-out
+  ;; Create a cell. Use within (row ...)
+  [cell  (case-> (-> cell-spec/c)
+                 (cell-expr? . -> . cell-spec/c)
+                 (cell-expr? string? . -> . cell-spec/c))]
+  
+  ;; Create a row of cells. Use within (sheet ..)
+  [row   (cell-spec/c ... . -> . row-spec?)]
+  
+  ;; Create a sheet with an optional name
+  [sheet ((row-spec?) (#:name string?) #:rest (listof row-spec?) . ->* . s:sheet?)]
+  
+  ;; Specify a reference to a nanemd cell
+  [ref   (string? . -> . id-ref?)]))
 
 ;; ---------------------------------------------------------------------------------------------------
 
@@ -51,15 +47,22 @@ TODO
 (struct row-spec (cells ids) #:transparent)           ; what is produced by (row ...)
 (struct id-ref (id) #:transparent)
 
+(define cell-spec/c
+  (or/c s:atomic-value? named-cell-spec? anon-cell-spec? 'nothing))
 
-(define (blank)
-  'nothing)
+(define (cell-expr? x)
+  (cond
+    [(s:atomic-value? x) #t]
+    [(id-ref? x)         #t]
+    [(pair? x)           (and (symbol? (car x))
+                              (andmap cell-expr? (cdr x))) ]
+    [else                #f]))
 
-;; cell : (or/c atomic-value? <expression>) -> cell-spec
-(define (cell v #:id [id #f])
-  (if id
-      (named-cell-spec v id)
-      (anon-cell-spec v)))
+(define cell
+  (case-lambda
+    [()     'nothing]
+    [(v)    (anon-cell-spec v)]
+    [(v id) (named-cell-spec v id)]))
 
 ;; ref : string? -> id-ref?
 (define (ref id)
@@ -90,7 +93,7 @@ TODO
 ;; Parse an entry in a row, pulling out the name if there is one
 (define (parse-cell-spec v)
   (cond
-    [(atomic-value? v)
+    [(s:atomic-value? v)
      (values (anon-cell-spec v) #f)]
     [(anon-cell-spec? v)
      (values v #f)]
@@ -98,15 +101,15 @@ TODO
      (values (anon-cell-spec (named-cell-spec-contents v))
              (named-cell-spec-id v))]))
 
-;; sheet : (list-of <row-spec>) [string?] -> sheet?
 ;; Two-pass sheet parser. The first pass extracts the names; the second pass makes
 ;; a sheet? and fills in the cell references
-(define (sheet #:name [name "unnamed-sheet"] . row-specs)
-  (let-values ([(n-rows rows ids) (sheet-iter row-specs)])
+;; There must be at least one row in the call to sheet. 
+(define (sheet #:name [name "unnamed-sheet"] first-row-spec . rest-row-specs)
+  (let-values ([(n-rows rows ids) (sheet-iter (cons first-row-spec rest-row-specs))])
     (let ([maybe-dup (duplicated-id ids)])
       (if maybe-dup
           (raise-argument-error 'sheet "Duplicate named reference" maybe-dup)
-          (sheet-type (make-dereferenced-array rows ids) null name)))))
+          (s:sheet (make-dereferenced-array rows ids) null name)))))
 
 ;; duplicated-id : (list-of (name ref)) -> name
 (define (duplicated-id ids)
@@ -116,26 +119,26 @@ TODO
 (define (make-dereferenced-array rows ids)
   ;; convert all the anon-cells to cells
   (let ([cells (map (λ (r) (map (anon-cell/ids->cell ids) (row-spec-cells r))) rows)])
-    (list*->array cells cell?)))
+    (list*->array cells s:cell?)))
 
 ;; anon-cell/ids->cell : (list-of (name ref)) -> anon-cell -> cell?
 ;; Turn something made by (cell ...) into an actual cell, replacing any named references with a
 ;; reference
 (define ((anon-cell/ids->cell ids) ac)
-  (cell-type ((expr/ids->cell-expr ids) (anon-cell-spec-contents ac))))
+  (s:cell ((expr/ids->cell-expr ids) (anon-cell-spec-contents ac))))
 
 ;; epxr/ids->cell-expr : -> cell-expr?
 (define ((expr/ids->cell-expr ids) expr)
   (cond
-    [(atomic-value? expr) (cell-value-return expr)]
-    [(id-ref? expr)       (reference-to (id-ref-id expr) ids)]
-    [(pair? expr)         (cell-app (car expr) (map (expr/ids->cell-expr ids) (cdr expr)))]))
+    [(s:atomic-value? expr) (s:cell-value-return expr)]
+    [(id-ref? expr)         (reference-to (id-ref-id expr) ids)]
+    [(pair? expr)           (s:cell-app (car expr) (map (expr/ids->cell-expr ids) (cdr expr)))]))
 
 ;; reference-to : string? (listof string? int int) -> cell-addr? 
 ;; Look up the reference in ids, replace with address found therein
 (define (reference-to name ids)
   (let ([index (cdr (assoc name ids))])
-    (cell-addr (car index) (cadr index) #t #t)))
+    (s:cell-addr (car index) (cadr index) #t #t)))
 
 ;; sheet-iter : list-of row-spec -> values n-rows (list-of (list-of cell)) ids
 ;; Collate the names from the rows, adding a row index

--- a/grid/main.rkt
+++ b/grid/main.rkt
@@ -1,3 +1,7 @@
 #lang racket/base
 
-;; Placeholder
+(require "grid.rkt")
+
+(provide
+ (all-from-out "grid.rkt"))
+

--- a/grid/tests-eval.rkt
+++ b/grid/tests-eval.rkt
@@ -9,7 +9,7 @@
 ;; ---------------------------------------------------------------------------------------------------
 
 (check-equal?
- (sheet-eval (sheet (row (blank))))
+ (sheet-eval (sheet (row (cell))))
  (array #[#['nothing]]))
 
 (check-equal?
@@ -30,13 +30,13 @@
 (check-equal?
  (sheet-eval
   (sheet
-   (row (cell 21 #:id "a-cell") (cell (ref "a-cell")))))
+   (row (cell 21 "a-cell") (cell (ref "a-cell")))))
  (array #[#[21 21]]))
 
 (check-equal?
  (sheet-eval
   (sheet
-   (row (cell 21 #:id "a-cell") (cell `(* 2 ,(ref "a-cell"))))))
+   (row (cell 21 "a-cell") (cell `(* 2 ,(ref "a-cell"))))))
  (array #[#[21 42]]))
 
 ;; --------------------------------------------------------------------------------

--- a/grid/tests-grid.rkt
+++ b/grid/tests-grid.rkt
@@ -10,5 +10,5 @@
 ;; ---------------------------------------------------------------------------------------------------
 
 (check-equal?
- (sheet (row (blank)) #:name "geranium")
+ (sheet (row (cell)) #:name "geranium")
  (sheet:sheet (array #[ #[ (sheet:cell (sheet:cell-value-return 'nothing))]]) null "geranium"))


### PR DESCRIPTION
- Within grid.rkt, use "prefix-in" to import sheet.rkt to avoid name clashes
- Redefine grid language; add contracts to provided forms
- Add grid/main.rkt (which simply re-provides everything provided by grid/grid.rkt)